### PR TITLE
Update the userdata search paths

### DIFF
--- a/gem/lib/ezq/utils/userdata.rb
+++ b/gem/lib/ezq/utils/userdata.rb
@@ -15,9 +15,10 @@ module EZQ
         end
       else
         search_paths = [
-          '/tmp/userdata.yml',
           File.join(__dir__, 'userdata.yml'),
-          File.join(Dir.pwd, 'userdata.yml')
+          File.join(Dir.pwd, 'userdata.yml'),
+          '/var/task/userdata.yml',
+          '/tmp/userdata.yml'
         ]
 
         search_paths.each do |path|


### PR DESCRIPTION
Add a Lambda-specific search path to accommodate Lambdas that are not
using an environment variable to supply userdata.

I had assumed that `File.join(__dir__, 'userdata.yml')` would take care
of both the EC2 and Lambda use cases, but this turns out to not be the
case. I suspect that since the entry point/shim scripts that the Lambdas
use are `cd`-ing to the `/tmp` directory first before invoking the EZQ
Processor, that may be subtly changing the output we get back from the
`Kernel.__dir__` method. To address this, just add an explicit check for
`/var/task/userdata.yml`.